### PR TITLE
Feature/moving easily between frames

### DIFF
--- a/cardiac/static/cardiac/segmentation.js
+++ b/cardiac/static/cardiac/segmentation.js
@@ -18,7 +18,6 @@ var g_motionModeContext;
 var g_createMotionModeImage = 0;
 var g_motionModeLine = -1;
 var g_moveMotionModeLIne = false;
-var g_shiftKeyPressed = false;
 var g_targetFrameTypes = {};
 var g_currentLabel = -1;
 
@@ -207,9 +206,6 @@ function setupSegmentation() {
         redrawSequence();
     });
 
-    $(document).on('keyup keydown', function(event) {
-        g_shiftKeyPressed = event.shiftKey;
-    });
 
     // Set first label active
     changeLabel(g_labelButtons[0].id);

--- a/spline_segmentation/static/spline_segmentation/segmentation.js
+++ b/spline_segmentation/static/spline_segmentation/segmentation.js
@@ -105,40 +105,6 @@ function setupSegmentation() {
         redrawSequence();
     });
 
-    var z = document.getElementById("canvas");
-    var baseWidth = 500;
-    var padding = 100;
-
-    var zoomStep = 30;
-
-    var handleWheel = function (event) {
-        // cross-browser wheel delta
-        // Chrome / IE: both are set to the same thing - WheelEvent for Chrome, MouseWheelEvent for IE
-        // Firefox: first one is undefined, second one is MouseScrollEvent
-        var e = window.event || event;
-        // Chrome / IE: first one is +/-120 (positive on mouse up), second one is zero
-        // Firefox: first one is undefined, second one is -/+3 (negative on mouse up)
-        var delta = Math.max(-1, Math.min(1, e.wheelDelta || -e.detail));
-
-        // Do something with `delta`
-        console.log(z.clientWidth, padding, zoomStep, delta)
-        var zz = z.clientWidth + zoomStep * delta;
-        zz = Math.max(zoomStep, Math.min(2 * baseWidth, zz));
-        console.log(zz)
-
-        z.style.width = zz + "px";
-
-        z.innerHTML = "<small>" + window.event + " | " + event +
-          "</small><br><small>" +   e.wheelDelta + " | " + e.detail +
-          "</small><br>" + delta + " | " + zz + " | " + z.clientWidth + "px";
-
-        e.preventDefault();
-    };
-
-    $('#canvas').bind('mousewheel DOMMouseScroll', function(event){
-        handleWheel(event);
-    });
-
     $('#canvas').dblclick(function(e) {
         if(g_move)
             return;

--- a/spline_segmentation/static/spline_segmentation/segmentation.js
+++ b/spline_segmentation/static/spline_segmentation/segmentation.js
@@ -7,7 +7,6 @@ var g_pointToMove = -1;
 var g_labelToMove = -1;
 var g_moveDistanceThreshold = 8;
 var g_drawLine = false;
-var g_shiftKeyPressed = false;
 var g_currentLabel = -1;
 
 function getMaxObjectID() {
@@ -21,9 +20,6 @@ function getMaxObjectID() {
 }
 
 function setupSegmentation() {
-
-    // Remove any previous event handlers
-    $('#canvas').off();
 
     // Define event callbacks
     $('#canvas').mousedown(function(e) {
@@ -144,10 +140,6 @@ function setupSegmentation() {
         }
 
         redrawSequence();
-    });
-
-    $(document).on('keyup keydown', function(event) {
-        g_shiftKeyPressed = event.shiftKey;
     });
 
     $(document).keydown(function(event) {


### PR DESCRIPTION
As discussed in #50 

Implemented moving easily between frames using mouse wheel and arrow keys as discussed in #50, also implemented holding shift to move between key/target frames. The zoom functionality in the spline segmentation task was removed.

Note that for the scroll wheel event, the mouse has to be over the canvas.

@jvoor maybe you also want to take a look at this

