### PR TITLE
Fixed bug with scrolling/key press to move between frames

### DIFF
--- a/annotationweb/static/annotationweb/annotationweb.js
+++ b/annotationweb/static/annotationweb/annotationweb.js
@@ -342,14 +342,18 @@ function loadSequence(image_sequence_id, start_frame, nrOfFrames, show_entire_se
             if(g_shiftKeyPressed) {
                 goToNextKeyFrame();
             } else {
-                goToFrame(g_currentFrameNr + 1);
+                if (g_currentFrameNr < end) {
+                    goToFrame(g_currentFrameNr + 1);
+                }
             }
         } else {
             // scroll down
             if(g_shiftKeyPressed) {
                 goToPreviousKeyFrame();
             } else {
-                goToFrame(g_currentFrameNr - 1);
+                if (g_currentFrameNr > start) {
+                    goToFrame(g_currentFrameNr - 1);
+                }
             }
         }
         event.preventDefault();
@@ -362,13 +366,17 @@ function loadSequence(image_sequence_id, start_frame, nrOfFrames, show_entire_se
             if(g_shiftKeyPressed) {
                 goToPreviousKeyFrame();
             } else {
-                goToFrame(g_currentFrameNr - 1);
+                if (g_currentFrameNr > start) {
+                    goToFrame(g_currentFrameNr - 1);
+                }
             }
         } else if(event.which === 39) { // Right
             if(g_shiftKeyPressed) {
                 goToNextKeyFrame();
             } else {
-                goToFrame(g_currentFrameNr + 1);
+                if (g_currentFrameNr < end) {
+                    goToFrame(g_currentFrameNr + 1);
+                }
             }
         }
     });


### PR DESCRIPTION
I noticed that when hovering over the canvas and scrolling, the current frame number incremented/decremented beyond the range of frames (for me, below 0 and above the total number of frames). The same bug happened with key left/right presses. The canvas keeps displaying the first/last frame in the sequence, but the browser console gives an error message:

```
segmentation.js:357 Uncaught TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(CSSImageValue or HTMLCanvasElement or HTMLImageElement or HTMLVideoElement or ImageBitmap or OffscreenCanvas or SVGImageElement or VideoFrame)'.
    at redrawSequence (segmentation.js:357)
    at goToFrame (annotationweb.js:71)
```

I added if statements to the calls to `goToFrame()` in annotationweb.js that seems to fix the problem.

(cherry picked from commit 5e25cf99447b178788308d4115e8bcf63458ea7a)