### PR TITLE
Mismatch between image_size and spacing when exporting splines

### DIFF
--- a/exporters/spline_segmentation_exporter.py
+++ b/exporters/spline_segmentation_exporter.py
@@ -247,6 +247,16 @@ class SplineSegmentationExporter(Exporter):
 
     @staticmethod
     def compute_scaling(image_size, spacing):
+        if len(spacing) > len(image_size):
+            warnings.warn(f'Image is {len(image_size)}D and spacing is {len(spacing)}D.'
+                          f'Dropping the extra axes in the spacing vector.')
+            for n in range(len(spacing) - len(image_size)):
+                spacing.pop(-1)
+        elif len(spacing) < len(image_size):
+            raise ValueError(f'Something wrong with the data:'
+                             f'image is {len(image_size)}D and spacing is {len(spacing)}D.')
+
+        assert len(image_size) == len(spacing), 'Image size and spacing are expected to have the same dimensions.'
         if len(spacing) == 2:
             aspect_ratio = image_size[0] / image_size[1]
             new_aspect_ratio = image_size[0] * spacing[0] / (image_size[1] * spacing[1])


### PR DESCRIPTION
Handling the case in which 2D images extracted from 3D data still hold the 3D spacing in their metadata. The spacing information will be cropped to match the image shape.

Added additional test to capture when image_size and spacing do not match