### PR TITLE
Fix bug #73

### DIFF
--- a/annotationweb/static/annotationweb/annotationweb.js
+++ b/annotationweb/static/annotationweb/annotationweb.js
@@ -37,13 +37,31 @@ function min(a, b) {
 }
 
 function mousePos(e, canvas) {
-    var scale =  g_canvasWidth / $('#canvas').width();
-    var mouseX = (e.pageX - canvas.offsetLeft)*scale;
-    var mouseY = (e.pageY - canvas.offsetTop)*scale;
+    // Get original dimension of the image being annotated (set in loadLandmarkTask)
+    const imgWidth = g_canvasWidth;
+    const imgHeight = g_canvasHeight;
+
+    // Get displayed dimensions (after CSS)
+    const displayedWidth = $('#canvas').width();
+    const displayedHeight = $('#canvas').height();
+
+    // Calculate scaling between original and displayed dimensions
+    const scale = Math.min(displayedWidth / imgWidth, displayedHeight / imgHeight);
+    const scaledWidth = imgWidth * scale;
+    const scaledHeight = imgHeight * scale;
+
+    // Scaling while keeping aspect ratio will create padding on the smallest side
+    const paddingX = (displayedWidth - scaledWidth) / 2;
+    const paddingY = (displayedHeight - scaledHeight) / 2;
+
+    // Adjust mouse coordinates so they match the image display
+    const mouseX = (e.offsetX - paddingX) / scale;
+    const mouseY = (e.offsetY - paddingY) / scale;
+
     return {
         x: mouseX,
-        y: mouseY,
-    }
+        y: mouseY
+    };
 }
 
 function incrementFrame() {

--- a/annotationweb/static/annotationweb/style.css
+++ b/annotationweb/static/annotationweb/style.css
@@ -149,7 +149,9 @@ th, td {
 }
 
 #canvas {
+    height: 85vh;
     width: 100%;
+    object-fit: contain;
 }
 
 #imageFilter form p {


### PR DESCRIPTION
Bug description:
https://github.com/smistad/annotationweb/issues/73

I changed the css and added code to scale height while keeping aspect ratio. Keeping aspect ratio with "object-fit: contain" create margin within the canvas on around the smallest side of the image, therefore I had to change the function that calculates the mouse position. For height I picked 85vh arbitrarily because it works on most reasonable computer screen resolutions. Not perfect but seems to work better than current.

It works on classification, bbox, landmarks, could not test it on other tasks because I don't have working examples. @smistad can you check for yourself, or provide me with files to create test dataset with?

@jpdefrutos  told me maybe I should have modified get_image_as_http_response() from utility instead:
[get_image_as_http_response](https://github.com/smistad/annotationweb/blob/master/common/utility.py#L12)

Please review and tell me whether this is a good fix.
