### PR TITLE
fix bug #72: not possible to add the first landmark on an image

### DIFF
--- a/landmark/static/landmark/landmark.js
+++ b/landmark/static/landmark/landmark.js
@@ -26,10 +26,12 @@ function setupLandmarkTask() {
                 console.log("adding landmark..");
                 // Check if already exists
                 let exists = false;
-                for(let i = 0; i < g_landmarks[g_currentFrameNr].length; ++i) {
-                    let landmark = g_landmarks[g_currentFrameNr][i];
-                    if(landmark.label_id === g_currentLabel && Math.abs(pos.x - landmark.x) < 6 && Math.abs(pos.y - landmark.y) < 6) {
-                        exists = true;
+                if(Object.keys(g_landmarks).length > 0) {
+                    for (let i = 0; i < g_landmarks[g_currentFrameNr].length; ++i) {
+                        let landmark = g_landmarks[g_currentFrameNr][i];
+                        if (landmark.label_id === g_currentLabel && Math.abs(pos.x - landmark.x) < 6 && Math.abs(pos.y - landmark.y) < 6) {
+                            exists = true;
+                        }
                     }
                 }
                 if(!exists)


### PR DESCRIPTION
See https://github.com/smistad/annotationweb/issues/72, https://github.com/smistad/annotationweb/issues/76

When adding a new landmark, some code uses `g_landmarks[g_currentFrameNr].length` to loop over all existing landmarks in order to check whether there is not already a landmark there. But if there is no landmark, `g_landmarks` is empty and the check crashes, making it impossible to add the first landmark. Fixed by hoping over this check if `g_landmarks` does not exist. `g_landmarks` is then created when the landmark is placed.