### PR TITLE
Fix bug #78: bboxes won't save

### DIFF
--- a/boundingbox/static/boundingbox/boundingbox.js
+++ b/boundingbox/static/boundingbox/boundingbox.js
@@ -71,6 +71,7 @@ function setupSegmentation() {
             return;
         g_paint = false;
         g_annotationHasChanged = true;
+        addKeyFrame(g_currentFrameNr);
         addBox(g_currentFrameNr, g_BBx, g_BBy, g_BBx2, g_BBy2, g_currentLabel);
         console.log('finished BB on ' + g_BBx + ' ' + g_BBy);
     });
@@ -78,6 +79,7 @@ function setupSegmentation() {
     $('#canvas').mouseleave(function(e){
         if(g_paint) {
             g_annotationHasChanged = true;
+            addKeyFrame(g_currentFrameNr);
             addBox(g_currentFrameNr, g_BBx, g_BBy, g_BBx2, g_BBy2, g_currentLabel);
             redrawSequence();
             g_paint = false;


### PR DESCRIPTION
See https://github.com/smistad/annotationweb/issues/78

Fixed by adding the current frame number as key frame when adding a box. This fixes downstream variable not being set such as `g_targetFrames` and allows saving to work normally. 

I noticed the logic on adding key frames being somewhat complicated in the landmark task and I don't fully understand it, so I hope this simple fix is ok. It works for single image annotations.